### PR TITLE
[ Setting ] 기본 DB 설정 및 JPA 환경 구성

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ out/
 
 ### VS Code ###
 .vscode/
+
+### key.yml ###
+/src/main/resources/application-key.yml

--- a/build.gradle
+++ b/build.gradle
@@ -24,13 +24,22 @@ repositories {
 }
 
 dependencies {
+    // MySQL
+    runtimeOnly 'com.mysql:mysql-connector-j'
+
+    // JPA
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+
+    // Security
     implementation 'org.springframework.boot:spring-boot-starter-security'
+
+    // Lombok, Web, Validation
+    compileOnly 'org.projectlombok:lombok'
+    annotationProcessor 'org.projectlombok:lombok'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
-    compileOnly 'org.projectlombok:lombok'
-    runtimeOnly 'com.mysql:mysql-connector-j'
-    annotationProcessor 'org.projectlombok:lombok'
+
+    // Test
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.application.name=onboarding

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,19 @@
+spring:
+  application:
+    name: onboarding
+
+  datasource:
+    url: ${DB_URL}
+    username: ${DB_USER}
+    password: ${DB_PASSWORD}
+    driver-class-name: com.mysql.cj.jdbc.Driver
+
+  jpa:
+    database-platform: org.hibernate.dialect.MySQL8Dialect
+    hibernate:
+      ddl-auto: update
+    properties:
+      hibernate:
+        show_sql: true
+        format_sql: true
+    open-in-view: false


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #1 

## 📝 Description

프로젝트에서 사용할 MySQL 데이터베이스 연결 및 JPA 환경을 설정

- MySQL 데이터베이스 연결 설정 추가
- JPA 설정 추가 (hibernate.ddl-auto, show_sql, format_sql 등)
- open-in-view: false 설정
- DB 연결 정보 (DB_URL, DB_USER, DB_PASSWORD)를 aplication-key.yml 을 생성하여 환경 변수로 관리

## 💬 To Reivewers

- ( 생략 )