### PR TITLE
[ Feat ] 사용자 회원가입 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,9 @@ dependencies {
     // Security
     implementation 'org.springframework.boot:spring-boot-starter-security'
 
+    // Swagger
+    implementation group: 'org.springdoc', name: 'springdoc-openapi-starter-webmvc-ui', version: '2.3.0'
+
     // Lombok, Web, Validation
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/backend/onboarding/OnboardingApplication.java
+++ b/src/main/java/com/backend/onboarding/OnboardingApplication.java
@@ -2,7 +2,9 @@ package com.backend.onboarding;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class OnboardingApplication {
 

--- a/src/main/java/com/backend/onboarding/application/res/ResAuthPostSignupDTOApiV1.java
+++ b/src/main/java/com/backend/onboarding/application/res/ResAuthPostSignupDTOApiV1.java
@@ -1,0 +1,28 @@
+package com.backend.onboarding.application.res;
+
+import com.backend.onboarding.domain.model.UserEntity;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ResAuthPostSignupDTOApiV1 {
+
+    private String username;
+    private String nickname;
+
+    // --
+    // TODO : 권한 추가 필요
+    // --
+
+    public static ResAuthPostSignupDTOApiV1 of(UserEntity userEntity) {
+        return ResAuthPostSignupDTOApiV1.builder()
+                .username(userEntity.getUsername())
+                .nickname(userEntity.getNickname())
+                .build();
+    }
+}

--- a/src/main/java/com/backend/onboarding/application/service/AuthServiceApiV1.java
+++ b/src/main/java/com/backend/onboarding/application/service/AuthServiceApiV1.java
@@ -1,0 +1,45 @@
+package com.backend.onboarding.application.service;
+
+import com.backend.onboarding.application.res.ResAuthPostSignupDTOApiV1;
+import com.backend.onboarding.domain.model.UserEntity;
+import com.backend.onboarding.domain.model.constraint.RoleType;
+import com.backend.onboarding.domain.repository.UserRepository;
+import com.backend.onboarding.presentation.req.ReqAuthPostSignupDTOApiV1;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class AuthServiceApiV1 {
+
+    private final PasswordEncoder passwordEncoder;
+    private final UserRepository userRepository;
+
+    @Transactional
+    public ResAuthPostSignupDTOApiV1 signup(ReqAuthPostSignupDTOApiV1 dto) {
+
+        checkUsernameDuplication(dto.getUsername());
+
+        UserEntity userEntityForSaving = UserEntity.create(
+                dto.getUsername(),
+                passwordEncoder.encode(dto.getPassword()),
+                dto.getNickname(),
+                RoleType.USER
+        );
+
+        return ResAuthPostSignupDTOApiV1.of(
+                userRepository.save(userEntityForSaving)
+        );
+    }
+
+    private void checkUsernameDuplication(String username) {
+        Optional<UserEntity> userEntityOptional = userRepository.findByUsername(username);
+        if (userEntityOptional.isPresent()) {
+            throw new IllegalArgumentException("이미 존재하는 아이디입니다.");
+        }
+    }
+}

--- a/src/main/java/com/backend/onboarding/domain/model/UserEntity.java
+++ b/src/main/java/com/backend/onboarding/domain/model/UserEntity.java
@@ -1,0 +1,52 @@
+package com.backend.onboarding.domain.model;
+
+import com.backend.onboarding.domain.model.constraint.RoleType;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "user")
+public class UserEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id", nullable = false, unique = true)
+    private Long id;
+
+    @Column(name = "username", nullable = false, unique = true)
+    private String username;
+
+    @Column(name = "password", nullable = false)
+    private String password;
+
+    @Column(name = "nickname", nullable = false)
+    private String nickname;
+
+    @Column(name = "role", nullable = false)
+    @Enumerated(value = EnumType.STRING)
+    private RoleType role;
+
+    @Builder
+    public UserEntity(String username, String password, String nickname, RoleType role) {
+        this.username = username;
+        this.password = password;
+        this.nickname = nickname;
+        this.role = role;
+    }
+
+    public static UserEntity create(String username, String password, String nickname, RoleType role) {
+        return UserEntity.builder()
+                .username(username)
+                .password(password)
+                .nickname(nickname)
+                .role(role)
+                .build();
+    }
+
+}
+

--- a/src/main/java/com/backend/onboarding/domain/model/UserEntity.java
+++ b/src/main/java/com/backend/onboarding/domain/model/UserEntity.java
@@ -6,6 +6,10 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.LocalDateTime;
 
 @Entity
 @Getter
@@ -30,6 +34,17 @@ public class UserEntity {
     @Column(name = "role", nullable = false)
     @Enumerated(value = EnumType.STRING)
     private RoleType role;
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @UpdateTimestamp
+    @Column(name = "modified_at" , nullable = false)
+    private LocalDateTime modifiedAt;
+
+    @Column(name = "deleted_at")
+    private LocalDateTime deletedAt;
 
     @Builder
     public UserEntity(String username, String password, String nickname, RoleType role) {

--- a/src/main/java/com/backend/onboarding/domain/model/constraint/RoleType.java
+++ b/src/main/java/com/backend/onboarding/domain/model/constraint/RoleType.java
@@ -1,0 +1,20 @@
+package com.backend.onboarding.domain.model.constraint;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum RoleType {
+
+    USER(Authority.USER),
+    ADMIN(Authority.ADMIN);
+
+    private final String authority;
+
+    public static class Authority {
+        public static final String USER = "회원";
+        public static final String ADMIN = "관리자";
+    }
+}
+

--- a/src/main/java/com/backend/onboarding/domain/repository/UserRepository.java
+++ b/src/main/java/com/backend/onboarding/domain/repository/UserRepository.java
@@ -1,0 +1,12 @@
+package com.backend.onboarding.domain.repository;
+
+import com.backend.onboarding.domain.model.UserEntity;
+
+import java.util.Optional;
+
+public interface UserRepository {
+
+    Optional<UserEntity> findByUsername(String username);
+
+    UserEntity save(UserEntity UserEntity);
+}

--- a/src/main/java/com/backend/onboarding/infrastructure/config/PasswordConfig.java
+++ b/src/main/java/com/backend/onboarding/infrastructure/config/PasswordConfig.java
@@ -1,0 +1,16 @@
+package com.backend.onboarding.infrastructure.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@Configuration
+public class PasswordConfig {
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+}

--- a/src/main/java/com/backend/onboarding/infrastructure/docs/AuthControllerApiV1Swagger.java
+++ b/src/main/java/com/backend/onboarding/infrastructure/docs/AuthControllerApiV1Swagger.java
@@ -1,0 +1,28 @@
+package com.backend.onboarding.infrastructure.docs;
+
+import com.backend.onboarding.application.res.ResAuthPostSignupDTOApiV1;
+import com.backend.onboarding.presentation.req.ReqAuthPostSignupDTOApiV1;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@Tag(name = "Auth", description = "회원가입, 로그인 인증 등 인증 관련 API를 제공합니다.")
+@RequestMapping("/v1/auth")
+public interface AuthControllerApiV1Swagger {
+
+    @Operation(summary = "회원가입", description = "회원가입을 하는 API 입니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "회원가입 성공", content = @Content(schema = @Schema(implementation = ResAuthPostSignupDTOApiV1.class))),
+            @ApiResponse(responseCode = "400", description = "회원가입 실패.", content = @Content(schema = @Schema(implementation = ResAuthPostSignupDTOApiV1.class)))
+    })
+    @PostMapping("/signup")
+    ResAuthPostSignupDTOApiV1 signup(@RequestBody @Valid ReqAuthPostSignupDTOApiV1 dto);
+
+}

--- a/src/main/java/com/backend/onboarding/infrastructure/docs/AuthControllerApiV1Swagger.java
+++ b/src/main/java/com/backend/onboarding/infrastructure/docs/AuthControllerApiV1Swagger.java
@@ -9,6 +9,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -23,6 +24,6 @@ public interface AuthControllerApiV1Swagger {
             @ApiResponse(responseCode = "400", description = "회원가입 실패.", content = @Content(schema = @Schema(implementation = ResAuthPostSignupDTOApiV1.class)))
     })
     @PostMapping("/signup")
-    ResAuthPostSignupDTOApiV1 signup(@RequestBody @Valid ReqAuthPostSignupDTOApiV1 dto);
+    ResponseEntity<ResAuthPostSignupDTOApiV1> signup(@RequestBody @Valid ReqAuthPostSignupDTOApiV1 dto);
 
 }

--- a/src/main/java/com/backend/onboarding/infrastructure/repository/JpaUserRepository.java
+++ b/src/main/java/com/backend/onboarding/infrastructure/repository/JpaUserRepository.java
@@ -1,0 +1,12 @@
+package com.backend.onboarding.infrastructure.repository;
+
+import com.backend.onboarding.domain.model.UserEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface JpaUserRepository extends JpaRepository<UserEntity, Long> {
+
+    Optional<UserEntity> findByUsername(String username);
+
+}

--- a/src/main/java/com/backend/onboarding/infrastructure/repository/UserRepositoryImpl.java
+++ b/src/main/java/com/backend/onboarding/infrastructure/repository/UserRepositoryImpl.java
@@ -1,0 +1,26 @@
+package com.backend.onboarding.infrastructure.repository;
+
+import com.backend.onboarding.domain.model.UserEntity;
+import com.backend.onboarding.domain.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+public class UserRepositoryImpl implements UserRepository {
+
+    private final JpaUserRepository jpaUserRepository;
+
+    @Override
+    public Optional<UserEntity> findByUsername(String username) {
+        return jpaUserRepository.findByUsername(username);
+    }
+
+    @Override
+    public UserEntity save(UserEntity userEntity) {
+        return jpaUserRepository.save(userEntity);
+    }
+
+}

--- a/src/main/java/com/backend/onboarding/presentation/controller/AuthControllerAPiV1.java
+++ b/src/main/java/com/backend/onboarding/presentation/controller/AuthControllerAPiV1.java
@@ -3,6 +3,8 @@ package com.backend.onboarding.presentation.controller;
 import com.backend.onboarding.application.res.ResAuthPostSignupDTOApiV1;
 import com.backend.onboarding.domain.model.UserEntity;
 import com.backend.onboarding.domain.model.constraint.RoleType;
+import com.backend.onboarding.infrastructure.docs.AuthControllerApiV1Swagger;
+import com.backend.onboarding.presentation.req.ReqAuthPostSignupDTOApiV1;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -13,10 +15,10 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/v1/auth")
-public class AuthControllerAPiV1 {
+public class AuthControllerAPiV1 implements AuthControllerApiV1Swagger {
 
     @PostMapping("/signup")
-    public ResAuthPostSignupDTOApiV1 signup(@RequestBody @Valid ResAuthPostSignupDTOApiV1 dto) {
+    public ResAuthPostSignupDTOApiV1 signup(@RequestBody @Valid ReqAuthPostSignupDTOApiV1 dto) {
 
         UserEntity dummy = UserEntity.create(
                 "dummy-user",

--- a/src/main/java/com/backend/onboarding/presentation/controller/AuthControllerAPiV1.java
+++ b/src/main/java/com/backend/onboarding/presentation/controller/AuthControllerAPiV1.java
@@ -1,0 +1,30 @@
+package com.backend.onboarding.presentation.controller;
+
+import com.backend.onboarding.application.res.ResAuthPostSignupDTOApiV1;
+import com.backend.onboarding.domain.model.UserEntity;
+import com.backend.onboarding.domain.model.constraint.RoleType;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/v1/auth")
+public class AuthControllerAPiV1 {
+
+    @PostMapping("/signup")
+    public ResAuthPostSignupDTOApiV1 signup(@RequestBody @Valid ResAuthPostSignupDTOApiV1 dto) {
+
+        UserEntity dummy = UserEntity.create(
+                "dummy-user",
+                "dummy-password",
+                "dummy-nickname",
+                RoleType.USER
+        );
+
+        return ResAuthPostSignupDTOApiV1.of(dummy);
+    }
+}

--- a/src/main/java/com/backend/onboarding/presentation/controller/AuthControllerAPiV1.java
+++ b/src/main/java/com/backend/onboarding/presentation/controller/AuthControllerAPiV1.java
@@ -1,8 +1,7 @@
 package com.backend.onboarding.presentation.controller;
 
 import com.backend.onboarding.application.res.ResAuthPostSignupDTOApiV1;
-import com.backend.onboarding.domain.model.UserEntity;
-import com.backend.onboarding.domain.model.constraint.RoleType;
+import com.backend.onboarding.application.service.AuthServiceApiV1;
 import com.backend.onboarding.infrastructure.docs.AuthControllerApiV1Swagger;
 import com.backend.onboarding.presentation.req.ReqAuthPostSignupDTOApiV1;
 import jakarta.validation.Valid;
@@ -17,16 +16,11 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/v1/auth")
 public class AuthControllerAPiV1 implements AuthControllerApiV1Swagger {
 
+    private final AuthServiceApiV1 authServiceApiV1;
+
     @PostMapping("/signup")
     public ResAuthPostSignupDTOApiV1 signup(@RequestBody @Valid ReqAuthPostSignupDTOApiV1 dto) {
-
-        UserEntity dummy = UserEntity.create(
-                "dummy-user",
-                "dummy-password",
-                "dummy-nickname",
-                RoleType.USER
-        );
-
-        return ResAuthPostSignupDTOApiV1.of(dummy);
+        return authServiceApiV1.signup(dto);
     }
+
 }

--- a/src/main/java/com/backend/onboarding/presentation/controller/AuthControllerAPiV1.java
+++ b/src/main/java/com/backend/onboarding/presentation/controller/AuthControllerAPiV1.java
@@ -6,6 +6,8 @@ import com.backend.onboarding.infrastructure.docs.AuthControllerApiV1Swagger;
 import com.backend.onboarding.presentation.req.ReqAuthPostSignupDTOApiV1;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -19,8 +21,11 @@ public class AuthControllerAPiV1 implements AuthControllerApiV1Swagger {
     private final AuthServiceApiV1 authServiceApiV1;
 
     @PostMapping("/signup")
-    public ResAuthPostSignupDTOApiV1 signup(@RequestBody @Valid ReqAuthPostSignupDTOApiV1 dto) {
-        return authServiceApiV1.signup(dto);
+    public ResponseEntity<ResAuthPostSignupDTOApiV1> signup(@RequestBody @Valid ReqAuthPostSignupDTOApiV1 dto) {
+        return new ResponseEntity<>(
+                authServiceApiV1.signup(dto),
+                HttpStatus.OK
+        );
     }
 
 }

--- a/src/main/java/com/backend/onboarding/presentation/req/ReqAuthPostSignupDTOApiV1.java
+++ b/src/main/java/com/backend/onboarding/presentation/req/ReqAuthPostSignupDTOApiV1.java
@@ -10,6 +10,7 @@ import lombok.NoArgsConstructor;
 public class ReqAuthPostSignupDTOApiV1 {
 
     @NotBlank(message = "아이디를 입력해주세요.")
+    @Pattern(regexp = "^[a-z][a-z0-9]{7,15}$", message = "아이디는 8~16자의 소문자 영문자와 숫자만 사용할 수 있으며, 첫 글자는 영문자여야 합니다.")
     private String username;
 
     @NotBlank(message = "비밀번호를 입력해주세요.")

--- a/src/main/java/com/backend/onboarding/presentation/req/ReqAuthPostSignupDTOApiV1.java
+++ b/src/main/java/com/backend/onboarding/presentation/req/ReqAuthPostSignupDTOApiV1.java
@@ -1,0 +1,23 @@
+package com.backend.onboarding.presentation.req;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class ReqAuthPostSignupDTOApiV1 {
+
+    @NotBlank(message = "아이디를 입력해주세요.")
+    private String username;
+
+    @NotBlank(message = "비밀번호를 입력해주세요.")
+    @Pattern(regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[$@$!%*#?&])[A-Za-z\\d$@$!%*#?&]{8,16}$",
+            message = "비밀번호는 8~16자리수여야 합니다. 영문 대소문자, 숫자, 특수문자를 1개 이상 포함해야 합니다.")
+    private String password;
+
+    @NotBlank(message = "닉네임를 입력해주세요.")
+    private String nickname;
+
+}

--- a/src/main/java/com/backend/onboarding/presentation/req/ReqAuthPostSignupDTOApiV1.java
+++ b/src/main/java/com/backend/onboarding/presentation/req/ReqAuthPostSignupDTOApiV1.java
@@ -2,11 +2,15 @@ package com.backend.onboarding.presentation.req;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
+@Builder
 @NoArgsConstructor
+@AllArgsConstructor
 public class ReqAuthPostSignupDTOApiV1 {
 
     @NotBlank(message = "아이디를 입력해주세요.")

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,6 +2,9 @@ spring:
   application:
     name: onboarding
 
+  config:
+    import: classpath:application-key.yml
+
   datasource:
     url: ${DB_URL}
     username: ${DB_USER}

--- a/src/test/java/com/backend/onboarding/service/AuthServiceApiV1Test.java
+++ b/src/test/java/com/backend/onboarding/service/AuthServiceApiV1Test.java
@@ -17,6 +17,8 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 
@@ -62,5 +64,31 @@ public class AuthServiceApiV1Test {
         // Then
         assertThat(response.getUsername()).isEqualTo(reqDto.getUsername());
         assertThat(response.getNickname()).isEqualTo(reqDto.getNickname());
+    }
+
+    @Test
+    @DisplayName("회원가입 실패 테스트 - 중복된 아이디")
+    public void testSignupFailure() {
+
+        // Given
+        ReqAuthPostSignupDTOApiV1 reqDto = ReqAuthPostSignupDTOApiV1.builder()
+                .username("testuser")
+                .password("Test123!")
+                .nickname("testnickname")
+                .build();
+
+        UserEntity existingUser = UserEntity.create(
+                reqDto.getUsername(),
+                "encodedPassword",
+                reqDto.getNickname(),
+                RoleType.USER
+        );
+
+        given(userRepository.findByUsername(reqDto.getUsername())).willReturn(Optional.of(existingUser));
+
+        // When & Then
+        assertThatThrownBy(
+                () -> authServiceApiV1.signup(reqDto))
+                .isInstanceOf(IllegalArgumentException.class).hasMessage("이미 존재하는 아이디입니다.");
     }
 }

--- a/src/test/java/com/backend/onboarding/service/AuthServiceApiV1Test.java
+++ b/src/test/java/com/backend/onboarding/service/AuthServiceApiV1Test.java
@@ -6,6 +6,7 @@ import com.backend.onboarding.domain.model.UserEntity;
 import com.backend.onboarding.domain.model.constraint.RoleType;
 import com.backend.onboarding.domain.repository.UserRepository;
 import com.backend.onboarding.presentation.req.ReqAuthPostSignupDTOApiV1;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -18,7 +19,6 @@ import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 
@@ -34,17 +34,22 @@ public class AuthServiceApiV1Test {
     @Mock
     private PasswordEncoder passwordEncoder;
 
+    private ReqAuthPostSignupDTOApiV1 reqDto;
+
+    @BeforeEach
+    public void setUp() {
+        reqDto = ReqAuthPostSignupDTOApiV1.builder()
+                .username("testuser")
+                .password("Test123!")
+                .nickname("testnickname")
+                .build();
+    }
+
     @Test
     @DisplayName("회원가입 성공 테스트")
     public void testSignupSuccess() {
 
         // Given
-        ReqAuthPostSignupDTOApiV1 reqDto = ReqAuthPostSignupDTOApiV1.builder()
-                .username("testuser")
-                .password("Test123!")
-                .nickname("testnickname")
-                .build();
-
         String encodedPassword = reqDto.getPassword();
 
         UserEntity savedUser = UserEntity.create(
@@ -71,12 +76,6 @@ public class AuthServiceApiV1Test {
     public void testSignupFailure() {
 
         // Given
-        ReqAuthPostSignupDTOApiV1 reqDto = ReqAuthPostSignupDTOApiV1.builder()
-                .username("testuser")
-                .password("Test123!")
-                .nickname("testnickname")
-                .build();
-
         UserEntity existingUser = UserEntity.create(
                 reqDto.getUsername(),
                 "encodedPassword",

--- a/src/test/java/com/backend/onboarding/service/AuthServiceApiV1Test.java
+++ b/src/test/java/com/backend/onboarding/service/AuthServiceApiV1Test.java
@@ -1,0 +1,66 @@
+package com.backend.onboarding.service;
+
+import com.backend.onboarding.application.res.ResAuthPostSignupDTOApiV1;
+import com.backend.onboarding.application.service.AuthServiceApiV1;
+import com.backend.onboarding.domain.model.UserEntity;
+import com.backend.onboarding.domain.model.constraint.RoleType;
+import com.backend.onboarding.domain.repository.UserRepository;
+import com.backend.onboarding.presentation.req.ReqAuthPostSignupDTOApiV1;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+public class AuthServiceApiV1Test {
+
+    @InjectMocks
+    private AuthServiceApiV1 authServiceApiV1;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private PasswordEncoder passwordEncoder;
+
+    @Test
+    @DisplayName("회원가입 성공 테스트")
+    public void testSignupSuccess() {
+
+        // Given
+        ReqAuthPostSignupDTOApiV1 reqDto = ReqAuthPostSignupDTOApiV1.builder()
+                .username("testuser")
+                .password("Test123!")
+                .nickname("testnickname")
+                .build();
+
+        String encodedPassword = reqDto.getPassword();
+
+        UserEntity savedUser = UserEntity.create(
+                reqDto.getUsername(),
+                encodedPassword,
+                reqDto.getNickname(),
+                RoleType.USER
+        );
+
+        given(userRepository.findByUsername(reqDto.getUsername())).willReturn(Optional.empty());
+        given(passwordEncoder.encode(reqDto.getPassword())).willReturn(encodedPassword);
+        given(userRepository.save(any(UserEntity.class))).willReturn(savedUser);
+
+        // When
+        ResAuthPostSignupDTOApiV1 response = authServiceApiV1.signup(reqDto);
+
+        // Then
+        assertThat(response.getUsername()).isEqualTo(reqDto.getUsername());
+        assertThat(response.getNickname()).isEqualTo(reqDto.getNickname());
+    }
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #3 

## 📝 Description

- 회원가입 기능을 구현했습니다.
- /v1/auth/signup 경로로 설정했습니다.
- 아이디(username): 영문자와 숫자를 포함한 8~16자 형식으로 정규식 검증을 수행합니다.
- 비밀번호(password): 영문 대소문자, 숫자, 특수문자를 포함한 8~16자 형식으로 정규식 검증을 수행합니다.
- AuthControllerApiV1Swagger 인터페이스를 통해 Swagger 문서화가 추가하였습니다.

### 회원가입 성공

- 회원가입 요청

```
{
    "username" : "system1234",
    "password" : "sysyem1234!",
    "nickname" : "system"
}
```

- 회원가입 성공 응답

![스크린샷 2025-02-15 오후 11 25 20](https://github.com/user-attachments/assets/18e48122-624c-407c-9e4c-b1e5cbc54120)

### 회원가입 실패 - 중복된 아이디

<img width="788" alt="스크린샷 2025-02-15 오후 11 27 08" src="https://github.com/user-attachments/assets/1c4aadf1-79f8-44d0-88bd-112a97fbf3a8" />

### 회원가입 실패 - 아이디 정규식 검증 실패
- 회원가입 요청 
```
{
    "username" : "1system",
    "password" : "sysyem1234!",
    "nickname" : "system"
}
```

- 회원가입 실패 응답
<img width="666" alt="스크린샷 2025-02-15 오후 11 29 02" src="https://github.com/user-attachments/assets/3f8a5fd6-f037-44ba-8584-1d82e4875dc2" />

### 회원가입 실패 - 비밀번호 정규식 검증 실패
- 회원가입 요청
```
{
    "username" : "system1234",
    "password" : "sysytem1",
    "nickname" : "system"
}
```

- 회원가입 실패 응답

![스크린샷 2025-02-15 오후 11 31 35](https://github.com/user-attachments/assets/7f9b33a3-de99-4420-bc88-38c015dc34f6)



## 💬 To Reivewers

- ( 생략 )
